### PR TITLE
build: replace GH_TOKEN with supplyally-bot

### DIFF
--- a/.github/workflows/on_daily.yml
+++ b/.github/workflows/on_daily.yml
@@ -30,5 +30,5 @@ jobs:
       - name: Push changes
         uses: ad-m/github-push-action@master
         with:
-          github_token: ${{ secrets.GH_TOKEN }}
+          github_token: ${{ secrets.GH_TOKEN_SUPPLYALLY_BOT }}
           force: true

--- a/.github/workflows/on_trigger.yml
+++ b/.github/workflows/on_trigger.yml
@@ -30,5 +30,5 @@ jobs:
       - name: Push changes
         uses: ad-m/github-push-action@master
         with:
-          github_token: ${{ secrets.GH_TOKEN }}
+          github_token: ${{ secrets.GH_TOKEN_SUPPLYALLY_BOT }}
           force: true


### PR DESCRIPTION
[Notion link](https://www.notion.so/sally-wallet/Deprecate-musket-dev-e0334798edd94330b58b176b76cd82c7) <!-- Remove this link if no relevant Notion link -->

This PR replaces usage of default `GITHUB_TOKEN` with `supplyally-bot` in our build workflows.